### PR TITLE
chore: Remove Buf plugin generation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,18 +13,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/protoc-gen-go-hashpb/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
 
       - name: Test
         run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,25 +12,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
 
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Log in to Buf plugin registry
-        uses: docker/login-action@v1
-        with:
-          registry: plugins.buf.build
-          username: cerbos
-          password: ${{ secrets.BUF_TOKEN }}
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/protoc-gen-go-hashpb/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 ---
 snapshot:
-  name_template: '{{ incminor .Version }}-prerelease'
+  name_template: "{{ incminor .Version }}-prerelease"
 
 builds:
   - main: .
@@ -18,23 +18,10 @@ builds:
     goarm:
       - 6
       - 7
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
       - -s -w -X github.com/cerbos/protoc-gen-go-hashpb/internal/generator.Version={{.Version}}
-dockers:
-  - image_templates:
-      - "plugins.buf.build/cerbos/protoc-gen-go-hashpb:{{ .Version }}"
-    goos: linux
-    goarch: amd64
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/amd64"
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A protobuf plugin to generate hash functions for messages.
 
-Hashing messages encoded using Protocol Buffers is tricky because there is [no guarantee that the serialized form is stable](https://developers.google.com/protocol-buffers/docs/encoding) between different implementations, architectures, or even library versions. 
+Hashing messages encoded using Protocol Buffers is tricky because there is [no guarantee that the serialized form is stable](https://developers.google.com/protocol-buffers/docs/encoding) between different implementations, architectures, or even library versions.
 This plugin generates a hash function that does a depth-first traversal of the populated values (including default values) of the message in field number order and feeds it to the provided `hash.Hash` implementation. Map values are accessed in key order as well. Because of this deterministic traversal order, the hash generated for two identical protobuf messages should be the same.
 
 NOTE: While we have tested this plugin quite extensively, some edge cases may remain. Use at your own risk.
@@ -10,8 +10,6 @@ NOTE: While we have tested this plugin quite extensively, some edge cases may re
 ## Install
 
 Download the latest binary for your environment from https://github.com/cerbos/protoc-gen-go-hashpb/releases.
-
-This plugin is also available from the Buf Schema Registry as `buf.build/cerbos/protoc-gen-go-hashpb` and can be used as a [remote plugin](https://docs.buf.build/bsr/remote-generation/remote-plugin-execution).
 
 Alternatively, install from source:
 
@@ -26,15 +24,8 @@ go install github.com/cerbos/protoc-gen-go-hashpb@latest
 With `protoc`:
 
 ```shell
-protoc --plugin protoc-gen-go-hashpb=${GOBIN}/protoc-gen-go-hashpb --go_out=. --go-hashpb_out=. *.proto 
+protoc --plugin protoc-gen-go-hashpb=${GOBIN}/protoc-gen-go-hashpb --go_out=. --go-hashpb_out=. *.proto
 ```
-
-With [`buf`](https://github.com/bufbuild/buf): 
-
-```shell
-buf generate --template='{"version":"v1","plugins":[{"name":"go","out":"."},{"name":"go-hashpb","out":"."}]}'
-```
-
 
 ### Calculate hashes using generated code
 


### PR DESCRIPTION
Buf remote plugins are now an Enterprise feature.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
