### PR TITLE
hash map key

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -222,12 +222,14 @@ func (g *codegen) genMapField(gf *protogen.GeneratedFile, field *protogen.Field)
 	if field.Desc.MapKey().Kind() == protoreflect.BoolKind {
 		for _, k := range []bool{false, true} {
 			gf.P("if v, ok := ", fieldName, "[", k, "]; ok {")
+			g.genSingularField(gf, field.Desc.MapKey(), k)
 			g.genSingularField(gf, field.Desc.MapValue(), "v")
 			gf.P("}")
 		}
 	} else {
 		gf.P("if len(", fieldName, ") > 0 {")
 		gf.P("for _, k := range ", sortedFn, "(", mapKeysFn, "(", fieldName, ")) {")
+		g.genSingularField(gf, field.Desc.MapKey(), "k")
 		g.genSingularField(gf, field.Desc.MapValue(), fmt.Sprintf("%s[k]", fieldName))
 		gf.P("}")
 		gf.P("}")


### PR DESCRIPTION
This is technically a breaking change, but not hashing keys of a map is definitely an implementation miss, when hashing `{foo: bar}` and `{baz: bar}`, i expect different hashes

Is there a way towards merging this in this repo ? Or thats too much of a breaking change ?