### PR TITLE
Reuse buffer in AppendVarint

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses:  actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.24.x
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses:  actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.24.x
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: release --config=.goreleaser.yml --clean

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -162,7 +162,7 @@ func (g *codegen) genHelperForMsg(gf *protogen.GeneratedFile, msg *protogen.Mess
 		return fields[i].Desc.Number() < fields[j].Desc.Number()
 	})
 
-	gf.P("func ", sumFuncName(msg.Desc), "(", receiverIdent, " *", msg.GoIdent, ",hasher ", hashFn, ", ignore map[string]struct{}) {")
+	gf.P("func ", sumFuncName(msg.Desc), "(", receiverIdent, " *", msg.GoIdent, ", hasher ", hashFn, ", ignore map[string]struct{}, b *[10]byte) {")
 
 	oneOfs := make(map[string]struct{})
 
@@ -224,7 +224,7 @@ func (g *codegen) genMapField(gf *protogen.GeneratedFile, field *protogen.Field)
 	if field.Desc.MapKey().Kind() == protoreflect.BoolKind {
 		for _, k := range []bool{false, true} {
 			gf.P("if v, ok := ", fieldName, "[", k, "]; ok {")
-			gf.P(appendVarintFn, "(nil, ", encodeBoolFn, "(", k, "))")
+			gf.P("_, _ = hasher.Write(", appendVarintFn, "(b[:0], ", encodeBoolFn, "(", k, ")))")
 			g.genSingularField(gf, field.Desc.MapValue(), "v")
 			gf.P("}")
 		}
@@ -243,60 +243,60 @@ func (g *codegen) genSingularField(gf *protogen.GeneratedFile, fieldDesc protore
 
 	switch fieldDesc.Kind() {
 	case protoreflect.BoolKind:
-		// hasher.Write(protowire.AppendVarint(nil, protowire.EncodeBool(...)))
-		gf.P(writeFn, appendVarintFn, "(nil, ", encodeBoolFn, "(", fieldName, ")))")
+		// hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(...)))
+		gf.P(writeFn, appendVarintFn, "(b[:0], ", encodeBoolFn, "(", fieldName, ")))")
 	case protoreflect.EnumKind:
-		// hasher.Write(protowire.AppendVarint(nil, uint64(...)))
-		gf.P(writeFn, appendVarintFn, "(nil, uint64(", fieldName, ")))")
+		// hasher.Write(protowire.AppendVarint(b[:0], uint64(...)))
+		gf.P(writeFn, appendVarintFn, "(b[:0], uint64(", fieldName, ")))")
 	case protoreflect.Int32Kind:
-		// hasher.Write(protowire.AppendVarint(nil, uint64(...)))
-		gf.P(writeFn, appendVarintFn, "(nil, uint64(", fieldName, ")))")
+		// hasher.Write(protowire.AppendVarint(b[:0], uint64(...)))
+		gf.P(writeFn, appendVarintFn, "(b[:0], uint64(", fieldName, ")))")
 	case protoreflect.Sint32Kind:
-		// hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(int64(...))))
-		gf.P(writeFn, appendVarintFn, "(nil, ", encodeZigZagFn, "(int64(", fieldName, "))))")
+		// hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(int64(...))))
+		gf.P(writeFn, appendVarintFn, "(b[:0], ", encodeZigZagFn, "(int64(", fieldName, "))))")
 	case protoreflect.Uint32Kind:
-		// hasher.Write(protowire.AppendVarint(nil, uint64(...)))
-		gf.P(writeFn, appendVarintFn, "(nil, uint64(", fieldName, ")))")
+		// hasher.Write(protowire.AppendVarint(b[:0], uint64(...)))
+		gf.P(writeFn, appendVarintFn, "(b[:0], uint64(", fieldName, ")))")
 	case protoreflect.Int64Kind:
-		// hasher.Write(protowire.AppendVarint(nil, uint64(...)))
-		gf.P(writeFn, appendVarintFn, "(nil, uint64(", fieldName, ")))")
+		// hasher.Write(protowire.AppendVarint(b[:0], uint64(...)))
+		gf.P(writeFn, appendVarintFn, "(b[:0], uint64(", fieldName, ")))")
 	case protoreflect.Sint64Kind:
-		// hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(...)))
-		gf.P(writeFn, appendVarintFn, "(nil, ", encodeZigZagFn, "(", fieldName, ")))")
+		// hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(...)))
+		gf.P(writeFn, appendVarintFn, "(b[:0], ", encodeZigZagFn, "(", fieldName, ")))")
 	case protoreflect.Uint64Kind:
-		// hasher.Write(protowire.AppendVarint(nil, ...))
-		gf.P(writeFn, appendVarintFn, "(nil, ", fieldName, "))")
+		// hasher.Write(protowire.AppendVarint(b[:0], ...))
+		gf.P(writeFn, appendVarintFn, "(b[:0], ", fieldName, "))")
 	case protoreflect.Sfixed32Kind:
-		// hasher.Write(protowire.AppendFixed32(nil, uint32(...)))
-		gf.P(writeFn, appendFixed32Fn, "(nil, uint32(", fieldName, ")))")
+		// hasher.Write(protowire.AppendFixed32(b[:0], uint32(...)))
+		gf.P(writeFn, appendFixed32Fn, "(b[:0], uint32(", fieldName, ")))")
 	case protoreflect.Fixed32Kind:
-		// hasher.Write(protowire.AppendFixed32(nil, uint32(...)))
-		gf.P(writeFn, appendFixed32Fn, "(nil, uint32(", fieldName, ")))")
+		// hasher.Write(protowire.AppendFixed32(b[:0], uint32(...)))
+		gf.P(writeFn, appendFixed32Fn, "(b[:0], uint32(", fieldName, ")))")
 	case protoreflect.FloatKind:
-		// hasher.Write(protowire.AppendFixed32(nil, math.Float32bits(...)))
-		gf.P(writeFn, appendFixed32Fn, "(nil,", float32BitsFn, "(", fieldName, ")))")
+		// hasher.Write(protowire.AppendFixed32(b[:0], math.Float32bits(...)))
+		gf.P(writeFn, appendFixed32Fn, "(b[:0], ", float32BitsFn, "(", fieldName, ")))")
 	case protoreflect.Sfixed64Kind:
-		// hasher.Write(protowire.AppendFixed64(nil, uint64(...)))
-		gf.P(writeFn, appendFixed64Fn, "(nil, uint64(", fieldName, ")))")
+		// hasher.Write(protowire.AppendFixed64(b[:0], uint64(...)))
+		gf.P(writeFn, appendFixed64Fn, "(b[:0], uint64(", fieldName, ")))")
 	case protoreflect.Fixed64Kind:
-		// hasher.Write(protowire.AppendFixed64(nil, ...))
-		gf.P(writeFn, appendFixed64Fn, "(nil, ", fieldName, "))")
+		// hasher.Write(protowire.AppendFixed64(b[:0], ...))
+		gf.P(writeFn, appendFixed64Fn, "(b[:0], ", fieldName, "))")
 	case protoreflect.DoubleKind:
-		// hasher.Write(protowire.AppendFixed64(nil, math.Float64bits(...)))
-		gf.P(writeFn, appendFixed64Fn, "(nil,", float64BitsFn, "(", fieldName, ")))")
+		// hasher.Write(protowire.AppendFixed64(b[:0], math.Float64bits(...)))
+		gf.P(writeFn, appendFixed64Fn, "(b[:0], ", float64BitsFn, "(", fieldName, ")))")
 	case protoreflect.StringKind:
-		// hasher.Write(protowire.AppendVarint(nil, uint64(len(s))))
+		// hasher.Write(protowire.AppendVarint(b[:0], uint64(len(s))))
 		// hasher.Write(unsafe.Slice(unsafe.StringData(s), len(s)))
-		gf.P(writeFn, appendVarintFn, "(nil, uint64(len(", fieldName, "))))")
+		gf.P(writeFn, appendVarintFn, "(b[:0], uint64(len(", fieldName, "))))")
 		gf.P(writeFn, unsafeSliceFn, "(", unsafeStringDataFn, "(", fieldName, "), len(", fieldName, "))", ")")
 	case protoreflect.BytesKind:
-		// hasher.Write(protowire.AppendVarint(nil, uint64(len(b))))
+		// hasher.Write(protowire.AppendVarint(b[:0], uint64(len(b))))
 		// hasher.Write(b)
-		gf.P(writeFn, appendVarintFn, "(nil, uint64(len(", fieldName, "))))")
+		gf.P(writeFn, appendVarintFn, "(b[:0], uint64(len(", fieldName, "))))")
 		gf.P(writeFn, fieldName, ")")
 	case protoreflect.MessageKind:
 		gf.P("if ", fieldName, " != nil {")
-		gf.P(sumFuncName(fieldDesc.Message()), "(", fieldName, ",hasher, ignore)")
+		gf.P(sumFuncName(fieldDesc.Message()), "(", fieldName, ", hasher, ignore, b)")
 		gf.P("}")
 	default:
 		panic(fmt.Errorf("unhandled field kind %s", fieldDesc.Kind().String()))
@@ -351,7 +351,8 @@ func (g *codegen) genMethodForMsg(gf *protogen.GeneratedFile, genFuncs map[strin
 	gf.P("// The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash")
 	gf.P("func (", receiverIdent, " *", msg.GoIdent, ") HashPB(hasher ", hashFn, ", ignore map[string]struct{}) {")
 	gf.P("if ", receiverIdent, " != nil {")
-	gf.P(sumFuncName(msg.Desc), "(", receiverIdent, ", hasher, ignore)")
+	gf.P("var b [10]byte")
+	gf.P(sumFuncName(msg.Desc), "(", receiverIdent, ", hasher, ignore, &b)")
 	gf.P("}")
 	gf.P("}")
 	gf.P()

--- a/internal/pb/all_types_hashpb.pb.go
+++ b/internal/pb/all_types_hashpb.pb.go
@@ -12,7 +12,8 @@ import (
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		cerbos_hashpb_test_TestAllTypes_hashpb_sum(m, hasher, ignore)
+		var b [10]byte
+		cerbos_hashpb_test_TestAllTypes_hashpb_sum(m, hasher, ignore, &b)
 	}
 }
 
@@ -20,7 +21,8 @@ func (m *TestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypes_NestedMessage) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m, hasher, ignore)
+		var b [10]byte
+		cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m, hasher, ignore, &b)
 	}
 }
 
@@ -28,7 +30,8 @@ func (m *TestAllTypes_NestedMessage) HashPB(hasher hash.Hash, ignore map[string]
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *NestedTestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m, hasher, ignore)
+		var b [10]byte
+		cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m, hasher, ignore, &b)
 	}
 }
 
@@ -36,7 +39,8 @@ func (m *NestedTestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypesOptional) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		cerbos_hashpb_test_TestAllTypesOptional_hashpb_sum(m, hasher, ignore)
+		var b [10]byte
+		cerbos_hashpb_test_TestAllTypesOptional_hashpb_sum(m, hasher, ignore, &b)
 	}
 }
 
@@ -44,6 +48,7 @@ func (m *TestAllTypesOptional) HashPB(hasher hash.Hash, ignore map[string]struct
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypesOptional_NestedMessage) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m, hasher, ignore)
+		var b [10]byte
+		cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m, hasher, ignore, &b)
 	}
 }

--- a/internal/pb/hashpb_helpers.pb.go
+++ b/internal/pb/hashpb_helpers.pb.go
@@ -17,208 +17,208 @@ import (
 	unsafe "unsafe"
 )
 
-func cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m *NestedTestAllTypes, hasher hash.Hash, ignore map[string]struct{}) {
+func cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m *NestedTestAllTypes, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["cerbos.hashpb.test.NestedTestAllTypes.child"]; !ok {
 		if m.GetChild() != nil {
-			cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m.GetChild(), hasher, ignore)
+			cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m.GetChild(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.NestedTestAllTypes.payload"]; !ok {
 		if m.GetPayload() != nil {
-			cerbos_hashpb_test_TestAllTypes_hashpb_sum(m.GetPayload(), hasher, ignore)
+			cerbos_hashpb_test_TestAllTypes_hashpb_sum(m.GetPayload(), hasher, ignore, b)
 		}
 	}
 }
 
-func cerbos_hashpb_test_NoFields_hashpb_sum(m *NoFields, hasher hash.Hash, ignore map[string]struct{}) {
+func cerbos_hashpb_test_NoFields_hashpb_sum(m *NoFields, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 }
 
-func cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m *TestAllTypesOptional_NestedMessage, hasher hash.Hash, ignore map[string]struct{}) {
+func cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m *TestAllTypesOptional_NestedMessage, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.NestedMessage.bb"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetBb())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetBb())))
 	}
 }
 
-func cerbos_hashpb_test_TestAllTypesOptional_hashpb_sum(m *TestAllTypesOptional, hasher hash.Hash, ignore map[string]struct{}) {
+func cerbos_hashpb_test_TestAllTypesOptional_hashpb_sum(m *TestAllTypesOptional, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_int32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSingleInt32())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSingleInt32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_int64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSingleInt64())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSingleInt64())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_uint32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSingleUint32())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSingleUint32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_uint64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, m.GetSingleUint64()))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], m.GetSingleUint64()))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_sint32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(int64(m.GetSingleSint32()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(int64(m.GetSingleSint32()))))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_sint64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(m.GetSingleSint64())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(m.GetSingleSint64())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_fixed32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, uint32(m.GetSingleFixed32())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], uint32(m.GetSingleFixed32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_fixed64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, m.GetSingleFixed64()))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], m.GetSingleFixed64()))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_sfixed32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, uint32(m.GetSingleSfixed32())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], uint32(m.GetSingleSfixed32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_sfixed64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, uint64(m.GetSingleSfixed64())))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], uint64(m.GetSingleSfixed64())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_float"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, math.Float32bits(m.GetSingleFloat())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], math.Float32bits(m.GetSingleFloat())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_double"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, math.Float64bits(m.GetSingleDouble())))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], math.Float64bits(m.GetSingleDouble())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_bool"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeBool(m.GetSingleBool())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(m.GetSingleBool())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_string"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetSingleString()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetSingleString()))))
 		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetSingleString()), len(m.GetSingleString())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_bytes"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetSingleBytes()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetSingleBytes()))))
 		_, _ = hasher.Write(m.GetSingleBytes())
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_nested_message"]; !ok {
 		if m.GetSingleNestedMessage() != nil {
-			cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m.GetSingleNestedMessage(), hasher, ignore)
+			cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m.GetSingleNestedMessage(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.standalone_enum"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetStandaloneEnum())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetStandaloneEnum())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_any"]; !ok {
 		if m.GetSingleAny() != nil {
-			google_protobuf_Any_hashpb_sum(m.GetSingleAny(), hasher, ignore)
+			google_protobuf_Any_hashpb_sum(m.GetSingleAny(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_duration"]; !ok {
 		if m.GetSingleDuration() != nil {
-			google_protobuf_Duration_hashpb_sum(m.GetSingleDuration(), hasher, ignore)
+			google_protobuf_Duration_hashpb_sum(m.GetSingleDuration(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_timestamp"]; !ok {
 		if m.GetSingleTimestamp() != nil {
-			google_protobuf_Timestamp_hashpb_sum(m.GetSingleTimestamp(), hasher, ignore)
+			google_protobuf_Timestamp_hashpb_sum(m.GetSingleTimestamp(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_struct"]; !ok {
 		if m.GetSingleStruct() != nil {
-			google_protobuf_Struct_hashpb_sum(m.GetSingleStruct(), hasher, ignore)
+			google_protobuf_Struct_hashpb_sum(m.GetSingleStruct(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_value"]; !ok {
 		if m.GetSingleValue() != nil {
-			google_protobuf_Value_hashpb_sum(m.GetSingleValue(), hasher, ignore)
+			google_protobuf_Value_hashpb_sum(m.GetSingleValue(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_int64_wrapper"]; !ok {
 		if m.GetSingleInt64Wrapper() != nil {
-			google_protobuf_Int64Value_hashpb_sum(m.GetSingleInt64Wrapper(), hasher, ignore)
+			google_protobuf_Int64Value_hashpb_sum(m.GetSingleInt64Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_int32_wrapper"]; !ok {
 		if m.GetSingleInt32Wrapper() != nil {
-			google_protobuf_Int32Value_hashpb_sum(m.GetSingleInt32Wrapper(), hasher, ignore)
+			google_protobuf_Int32Value_hashpb_sum(m.GetSingleInt32Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_double_wrapper"]; !ok {
 		if m.GetSingleDoubleWrapper() != nil {
-			google_protobuf_DoubleValue_hashpb_sum(m.GetSingleDoubleWrapper(), hasher, ignore)
+			google_protobuf_DoubleValue_hashpb_sum(m.GetSingleDoubleWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_float_wrapper"]; !ok {
 		if m.GetSingleFloatWrapper() != nil {
-			google_protobuf_FloatValue_hashpb_sum(m.GetSingleFloatWrapper(), hasher, ignore)
+			google_protobuf_FloatValue_hashpb_sum(m.GetSingleFloatWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_uint64_wrapper"]; !ok {
 		if m.GetSingleUint64Wrapper() != nil {
-			google_protobuf_UInt64Value_hashpb_sum(m.GetSingleUint64Wrapper(), hasher, ignore)
+			google_protobuf_UInt64Value_hashpb_sum(m.GetSingleUint64Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_uint32_wrapper"]; !ok {
 		if m.GetSingleUint32Wrapper() != nil {
-			google_protobuf_UInt32Value_hashpb_sum(m.GetSingleUint32Wrapper(), hasher, ignore)
+			google_protobuf_UInt32Value_hashpb_sum(m.GetSingleUint32Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_string_wrapper"]; !ok {
 		if m.GetSingleStringWrapper() != nil {
-			google_protobuf_StringValue_hashpb_sum(m.GetSingleStringWrapper(), hasher, ignore)
+			google_protobuf_StringValue_hashpb_sum(m.GetSingleStringWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_bool_wrapper"]; !ok {
 		if m.GetSingleBoolWrapper() != nil {
-			google_protobuf_BoolValue_hashpb_sum(m.GetSingleBoolWrapper(), hasher, ignore)
+			google_protobuf_BoolValue_hashpb_sum(m.GetSingleBoolWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypesOptional.single_bytes_wrapper"]; !ok {
 		if m.GetSingleBytesWrapper() != nil {
-			google_protobuf_BytesValue_hashpb_sum(m.GetSingleBytesWrapper(), hasher, ignore)
+			google_protobuf_BytesValue_hashpb_sum(m.GetSingleBytesWrapper(), hasher, ignore, b)
 		}
 	}
 }
 
-func cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m *TestAllTypes_NestedMessage, hasher hash.Hash, ignore map[string]struct{}) {
+func cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m *TestAllTypes_NestedMessage, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.NestedMessage.bb"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetBb())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetBb())))
 	}
 }
 
-func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Hash, ignore map[string]struct{}) {
+func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_int32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSingleInt32())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSingleInt32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_int64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSingleInt64())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSingleInt64())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_uint32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSingleUint32())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSingleUint32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_uint64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, m.GetSingleUint64()))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], m.GetSingleUint64()))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_sint32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(int64(m.GetSingleSint32()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(int64(m.GetSingleSint32()))))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_sint64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(m.GetSingleSint64())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(m.GetSingleSint64())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_fixed32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, uint32(m.GetSingleFixed32())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], uint32(m.GetSingleFixed32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_fixed64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, m.GetSingleFixed64()))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], m.GetSingleFixed64()))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_sfixed32"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, uint32(m.GetSingleSfixed32())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], uint32(m.GetSingleSfixed32())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_sfixed64"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, uint64(m.GetSingleSfixed64())))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], uint64(m.GetSingleSfixed64())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_float"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, math.Float32bits(m.GetSingleFloat())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], math.Float32bits(m.GetSingleFloat())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_double"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, math.Float64bits(m.GetSingleDouble())))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], math.Float64bits(m.GetSingleDouble())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_bool"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeBool(m.GetSingleBool())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(m.GetSingleBool())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_string"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetSingleString()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetSingleString()))))
 		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetSingleString()), len(m.GetSingleString())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_bytes"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetSingleBytes()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetSingleBytes()))))
 		_, _ = hasher.Write(m.GetSingleBytes())
 	}
 	if m.NestedType != nil {
@@ -226,111 +226,111 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 			switch t := m.NestedType.(type) {
 			case *TestAllTypes_SingleNestedMessage:
 				if t.SingleNestedMessage != nil {
-					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(t.SingleNestedMessage, hasher, ignore)
+					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(t.SingleNestedMessage, hasher, ignore, b)
 				}
 			case *TestAllTypes_SingleNestedEnum:
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(t.SingleNestedEnum)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(t.SingleNestedEnum)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.standalone_enum"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetStandaloneEnum())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetStandaloneEnum())))
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_int32"]; !ok {
 		if len(m.RepeatedInt32) > 0 {
 			for _, v := range m.RepeatedInt32 {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(v)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_int64"]; !ok {
 		if len(m.RepeatedInt64) > 0 {
 			for _, v := range m.RepeatedInt64 {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(v)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_uint32"]; !ok {
 		if len(m.RepeatedUint32) > 0 {
 			for _, v := range m.RepeatedUint32 {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(v)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_uint64"]; !ok {
 		if len(m.RepeatedUint64) > 0 {
 			for _, v := range m.RepeatedUint64 {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, v))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], v))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_sint32"]; !ok {
 		if len(m.RepeatedSint32) > 0 {
 			for _, v := range m.RepeatedSint32 {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(int64(v))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(int64(v))))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_sint64"]; !ok {
 		if len(m.RepeatedSint64) > 0 {
 			for _, v := range m.RepeatedSint64 {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeZigZag(v)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeZigZag(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_fixed32"]; !ok {
 		if len(m.RepeatedFixed32) > 0 {
 			for _, v := range m.RepeatedFixed32 {
-				_, _ = hasher.Write(protowire.AppendFixed32(nil, uint32(v)))
+				_, _ = hasher.Write(protowire.AppendFixed32(b[:0], uint32(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_fixed64"]; !ok {
 		if len(m.RepeatedFixed64) > 0 {
 			for _, v := range m.RepeatedFixed64 {
-				_, _ = hasher.Write(protowire.AppendFixed64(nil, v))
+				_, _ = hasher.Write(protowire.AppendFixed64(b[:0], v))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_sfixed32"]; !ok {
 		if len(m.RepeatedSfixed32) > 0 {
 			for _, v := range m.RepeatedSfixed32 {
-				_, _ = hasher.Write(protowire.AppendFixed32(nil, uint32(v)))
+				_, _ = hasher.Write(protowire.AppendFixed32(b[:0], uint32(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_sfixed64"]; !ok {
 		if len(m.RepeatedSfixed64) > 0 {
 			for _, v := range m.RepeatedSfixed64 {
-				_, _ = hasher.Write(protowire.AppendFixed64(nil, uint64(v)))
+				_, _ = hasher.Write(protowire.AppendFixed64(b[:0], uint64(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_float"]; !ok {
 		if len(m.RepeatedFloat) > 0 {
 			for _, v := range m.RepeatedFloat {
-				_, _ = hasher.Write(protowire.AppendFixed32(nil, math.Float32bits(v)))
+				_, _ = hasher.Write(protowire.AppendFixed32(b[:0], math.Float32bits(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_double"]; !ok {
 		if len(m.RepeatedDouble) > 0 {
 			for _, v := range m.RepeatedDouble {
-				_, _ = hasher.Write(protowire.AppendFixed64(nil, math.Float64bits(v)))
+				_, _ = hasher.Write(protowire.AppendFixed64(b[:0], math.Float64bits(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_bool"]; !ok {
 		if len(m.RepeatedBool) > 0 {
 			for _, v := range m.RepeatedBool {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeBool(v)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_string"]; !ok {
 		if len(m.RepeatedString) > 0 {
 			for _, v := range m.RepeatedString {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(v))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(v))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(v), len(v)))
 			}
 		}
@@ -338,7 +338,7 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_bytes"]; !ok {
 		if len(m.RepeatedBytes) > 0 {
 			for _, v := range m.RepeatedBytes {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(v))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(v))))
 				_, _ = hasher.Write(v)
 			}
 		}
@@ -347,7 +347,7 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 		if len(m.RepeatedNestedMessage) > 0 {
 			for _, v := range m.RepeatedNestedMessage {
 				if v != nil {
-					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(v, hasher, ignore)
+					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(v, hasher, ignore, b)
 				}
 			}
 		}
@@ -355,14 +355,14 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_nested_enum"]; !ok {
 		if len(m.RepeatedNestedEnum) > 0 {
 			for _, v := range m.RepeatedNestedEnum {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(v)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(v)))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_string_piece"]; !ok {
 		if len(m.RepeatedStringPiece) > 0 {
 			for _, v := range m.RepeatedStringPiece {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(v))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(v))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(v), len(v)))
 			}
 		}
@@ -370,7 +370,7 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.repeated_cord"]; !ok {
 		if len(m.RepeatedCord) > 0 {
 			for _, v := range m.RepeatedCord {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(v))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(v))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(v), len(v)))
 			}
 		}
@@ -379,7 +379,7 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 		if len(m.RepeatedLazyMessage) > 0 {
 			for _, v := range m.RepeatedLazyMessage {
 				if v != nil {
-					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(v, hasher, ignore)
+					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(v, hasher, ignore, b)
 				}
 			}
 		}
@@ -387,9 +387,9 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_string_string"]; !ok {
 		if len(m.MapStringString) > 0 {
 			for _, k := range slices.Sorted(maps.Keys(m.MapStringString)) {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(k))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.MapStringString[k]))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapStringString[k]))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapStringString[k]), len(m.MapStringString[k])))
 			}
 		}
@@ -397,8 +397,8 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_uint64_string"]; !ok {
 		if len(m.MapUint64String) > 0 {
 			for _, k := range slices.Sorted(maps.Keys(m.MapUint64String)) {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, k))
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.MapUint64String[k]))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], k))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapUint64String[k]))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapUint64String[k]), len(m.MapUint64String[k])))
 			}
 		}
@@ -406,237 +406,237 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_int32_string"]; !ok {
 		if len(m.MapInt32String) > 0 {
 			for _, k := range slices.Sorted(maps.Keys(m.MapInt32String)) {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(k)))
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.MapInt32String[k]))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapInt32String[k]))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapInt32String[k]), len(m.MapInt32String[k])))
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_bool_string"]; !ok {
 		if v, ok := m.MapBoolString[false]; ok {
-			protowire.AppendVarint(nil, protowire.EncodeBool(false))
-			_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(v))))
+			_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(false)))
+			_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(v))))
 			_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(v), len(v)))
 		}
 		if v, ok := m.MapBoolString[true]; ok {
-			protowire.AppendVarint(nil, protowire.EncodeBool(true))
-			_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(v))))
+			_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(true)))
+			_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(v))))
 			_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(v), len(v)))
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_int64_nested_type"]; !ok {
 		if len(m.MapInt64NestedType) > 0 {
 			for _, k := range slices.Sorted(maps.Keys(m.MapInt64NestedType)) {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(k)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
 				if m.MapInt64NestedType[k] != nil {
-					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m.MapInt64NestedType[k], hasher, ignore)
+					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m.MapInt64NestedType[k], hasher, ignore, b)
 				}
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_any"]; !ok {
 		if m.GetSingleAny() != nil {
-			google_protobuf_Any_hashpb_sum(m.GetSingleAny(), hasher, ignore)
+			google_protobuf_Any_hashpb_sum(m.GetSingleAny(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_duration"]; !ok {
 		if m.GetSingleDuration() != nil {
-			google_protobuf_Duration_hashpb_sum(m.GetSingleDuration(), hasher, ignore)
+			google_protobuf_Duration_hashpb_sum(m.GetSingleDuration(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_timestamp"]; !ok {
 		if m.GetSingleTimestamp() != nil {
-			google_protobuf_Timestamp_hashpb_sum(m.GetSingleTimestamp(), hasher, ignore)
+			google_protobuf_Timestamp_hashpb_sum(m.GetSingleTimestamp(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_struct"]; !ok {
 		if m.GetSingleStruct() != nil {
-			google_protobuf_Struct_hashpb_sum(m.GetSingleStruct(), hasher, ignore)
+			google_protobuf_Struct_hashpb_sum(m.GetSingleStruct(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_value"]; !ok {
 		if m.GetSingleValue() != nil {
-			google_protobuf_Value_hashpb_sum(m.GetSingleValue(), hasher, ignore)
+			google_protobuf_Value_hashpb_sum(m.GetSingleValue(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_int64_wrapper"]; !ok {
 		if m.GetSingleInt64Wrapper() != nil {
-			google_protobuf_Int64Value_hashpb_sum(m.GetSingleInt64Wrapper(), hasher, ignore)
+			google_protobuf_Int64Value_hashpb_sum(m.GetSingleInt64Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_int32_wrapper"]; !ok {
 		if m.GetSingleInt32Wrapper() != nil {
-			google_protobuf_Int32Value_hashpb_sum(m.GetSingleInt32Wrapper(), hasher, ignore)
+			google_protobuf_Int32Value_hashpb_sum(m.GetSingleInt32Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_double_wrapper"]; !ok {
 		if m.GetSingleDoubleWrapper() != nil {
-			google_protobuf_DoubleValue_hashpb_sum(m.GetSingleDoubleWrapper(), hasher, ignore)
+			google_protobuf_DoubleValue_hashpb_sum(m.GetSingleDoubleWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_float_wrapper"]; !ok {
 		if m.GetSingleFloatWrapper() != nil {
-			google_protobuf_FloatValue_hashpb_sum(m.GetSingleFloatWrapper(), hasher, ignore)
+			google_protobuf_FloatValue_hashpb_sum(m.GetSingleFloatWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_uint64_wrapper"]; !ok {
 		if m.GetSingleUint64Wrapper() != nil {
-			google_protobuf_UInt64Value_hashpb_sum(m.GetSingleUint64Wrapper(), hasher, ignore)
+			google_protobuf_UInt64Value_hashpb_sum(m.GetSingleUint64Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_uint32_wrapper"]; !ok {
 		if m.GetSingleUint32Wrapper() != nil {
-			google_protobuf_UInt32Value_hashpb_sum(m.GetSingleUint32Wrapper(), hasher, ignore)
+			google_protobuf_UInt32Value_hashpb_sum(m.GetSingleUint32Wrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_string_wrapper"]; !ok {
 		if m.GetSingleStringWrapper() != nil {
-			google_protobuf_StringValue_hashpb_sum(m.GetSingleStringWrapper(), hasher, ignore)
+			google_protobuf_StringValue_hashpb_sum(m.GetSingleStringWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_bool_wrapper"]; !ok {
 		if m.GetSingleBoolWrapper() != nil {
-			google_protobuf_BoolValue_hashpb_sum(m.GetSingleBoolWrapper(), hasher, ignore)
+			google_protobuf_BoolValue_hashpb_sum(m.GetSingleBoolWrapper(), hasher, ignore, b)
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.single_bytes_wrapper"]; !ok {
 		if m.GetSingleBytesWrapper() != nil {
-			google_protobuf_BytesValue_hashpb_sum(m.GetSingleBytesWrapper(), hasher, ignore)
+			google_protobuf_BytesValue_hashpb_sum(m.GetSingleBytesWrapper(), hasher, ignore, b)
 		}
 	}
 }
 
-func google_protobuf_Any_hashpb_sum(m *anypb.Any, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Any_hashpb_sum(m *anypb.Any, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Any.type_url"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetTypeUrl()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetTypeUrl()))))
 		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetTypeUrl()), len(m.GetTypeUrl())))
 	}
 	if _, ok := ignore["google.protobuf.Any.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetValue()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetValue()))))
 		_, _ = hasher.Write(m.GetValue())
 	}
 }
 
-func google_protobuf_BoolValue_hashpb_sum(m *wrapperspb.BoolValue, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_BoolValue_hashpb_sum(m *wrapperspb.BoolValue, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.BoolValue.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeBool(m.GetValue())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(m.GetValue())))
 	}
 }
 
-func google_protobuf_BytesValue_hashpb_sum(m *wrapperspb.BytesValue, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_BytesValue_hashpb_sum(m *wrapperspb.BytesValue, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.BytesValue.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetValue()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetValue()))))
 		_, _ = hasher.Write(m.GetValue())
 	}
 }
 
-func google_protobuf_DoubleValue_hashpb_sum(m *wrapperspb.DoubleValue, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_DoubleValue_hashpb_sum(m *wrapperspb.DoubleValue, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.DoubleValue.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed64(nil, math.Float64bits(m.GetValue())))
+		_, _ = hasher.Write(protowire.AppendFixed64(b[:0], math.Float64bits(m.GetValue())))
 	}
 }
 
-func google_protobuf_Duration_hashpb_sum(m *durationpb.Duration, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Duration_hashpb_sum(m *durationpb.Duration, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Duration.seconds"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSeconds())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSeconds())))
 	}
 	if _, ok := ignore["google.protobuf.Duration.nanos"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetNanos())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetNanos())))
 	}
 }
 
-func google_protobuf_FloatValue_hashpb_sum(m *wrapperspb.FloatValue, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_FloatValue_hashpb_sum(m *wrapperspb.FloatValue, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.FloatValue.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendFixed32(nil, math.Float32bits(m.GetValue())))
+		_, _ = hasher.Write(protowire.AppendFixed32(b[:0], math.Float32bits(m.GetValue())))
 	}
 }
 
-func google_protobuf_Int32Value_hashpb_sum(m *wrapperspb.Int32Value, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Int32Value_hashpb_sum(m *wrapperspb.Int32Value, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Int32Value.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetValue())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetValue())))
 	}
 }
 
-func google_protobuf_Int64Value_hashpb_sum(m *wrapperspb.Int64Value, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Int64Value_hashpb_sum(m *wrapperspb.Int64Value, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Int64Value.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetValue())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetValue())))
 	}
 }
 
-func google_protobuf_ListValue_hashpb_sum(m *structpb.ListValue, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_ListValue_hashpb_sum(m *structpb.ListValue, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.ListValue.values"]; !ok {
 		if len(m.Values) > 0 {
 			for _, v := range m.Values {
 				if v != nil {
-					google_protobuf_Value_hashpb_sum(v, hasher, ignore)
+					google_protobuf_Value_hashpb_sum(v, hasher, ignore, b)
 				}
 			}
 		}
 	}
 }
 
-func google_protobuf_StringValue_hashpb_sum(m *wrapperspb.StringValue, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_StringValue_hashpb_sum(m *wrapperspb.StringValue, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.StringValue.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(m.GetValue()))))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.GetValue()))))
 		_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.GetValue()), len(m.GetValue())))
 	}
 }
 
-func google_protobuf_Struct_hashpb_sum(m *structpb.Struct, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Struct_hashpb_sum(m *structpb.Struct, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Struct.fields"]; !ok {
 		if len(m.Fields) > 0 {
 			for _, k := range slices.Sorted(maps.Keys(m.Fields)) {
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(k))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
 				if m.Fields[k] != nil {
-					google_protobuf_Value_hashpb_sum(m.Fields[k], hasher, ignore)
+					google_protobuf_Value_hashpb_sum(m.Fields[k], hasher, ignore, b)
 				}
 			}
 		}
 	}
 }
 
-func google_protobuf_Timestamp_hashpb_sum(m *timestamppb.Timestamp, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Timestamp_hashpb_sum(m *timestamppb.Timestamp, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Timestamp.seconds"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetSeconds())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetSeconds())))
 	}
 	if _, ok := ignore["google.protobuf.Timestamp.nanos"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetNanos())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetNanos())))
 	}
 }
 
-func google_protobuf_UInt32Value_hashpb_sum(m *wrapperspb.UInt32Value, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_UInt32Value_hashpb_sum(m *wrapperspb.UInt32Value, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.UInt32Value.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(m.GetValue())))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(m.GetValue())))
 	}
 }
 
-func google_protobuf_UInt64Value_hashpb_sum(m *wrapperspb.UInt64Value, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_UInt64Value_hashpb_sum(m *wrapperspb.UInt64Value, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.UInt64Value.value"]; !ok {
-		_, _ = hasher.Write(protowire.AppendVarint(nil, m.GetValue()))
+		_, _ = hasher.Write(protowire.AppendVarint(b[:0], m.GetValue()))
 	}
 }
 
-func google_protobuf_Value_hashpb_sum(m *structpb.Value, hasher hash.Hash, ignore map[string]struct{}) {
+func google_protobuf_Value_hashpb_sum(m *structpb.Value, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if m.Kind != nil {
 		if _, ok := ignore["google.protobuf.Value.kind"]; !ok {
 			switch t := m.Kind.(type) {
 			case *structpb.Value_NullValue:
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(t.NullValue)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(t.NullValue)))
 			case *structpb.Value_NumberValue:
-				_, _ = hasher.Write(protowire.AppendFixed64(nil, math.Float64bits(t.NumberValue)))
+				_, _ = hasher.Write(protowire.AppendFixed64(b[:0], math.Float64bits(t.NumberValue)))
 			case *structpb.Value_StringValue:
-				_, _ = hasher.Write(protowire.AppendVarint(nil, uint64(len(t.StringValue))))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(t.StringValue))))
 				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(t.StringValue), len(t.StringValue)))
 			case *structpb.Value_BoolValue:
-				_, _ = hasher.Write(protowire.AppendVarint(nil, protowire.EncodeBool(t.BoolValue)))
+				_, _ = hasher.Write(protowire.AppendVarint(b[:0], protowire.EncodeBool(t.BoolValue)))
 			case *structpb.Value_StructValue:
 				if t.StructValue != nil {
-					google_protobuf_Struct_hashpb_sum(t.StructValue, hasher, ignore)
+					google_protobuf_Struct_hashpb_sum(t.StructValue, hasher, ignore, b)
 				}
 			case *structpb.Value_ListValue:
 				if t.ListValue != nil {
-					google_protobuf_ListValue_hashpb_sum(t.ListValue, hasher, ignore)
+					google_protobuf_ListValue_hashpb_sum(t.ListValue, hasher, ignore, b)
 				}
 			}
 		}


### PR DESCRIPTION
- `protowire.AddVarint` encodes a number using maximum 10 bytes, so we pass the buffer from `HashPB` to avoid allocations in this function.
- Fix a bug. if a map has a boolean key, the encoded value is not hashed.

```txt
goos: linux
goarch: amd64
pkg: github.com/cerbos/protoc-gen-go-hashpb/internal/generator
cpu: AMD Ryzen AI 9 HX 370 w/ Radeon 890M           
                      │  before.txt  │              after.txt              │
                      │    sec/op    │   sec/op     vs base                │
HashPB/nesting=1-24     17.680µ ± 1%   9.648µ ± 2%  -45.43% (p=0.000 n=10)
HashPB/nesting=5-24      88.85µ ± 3%   46.70µ ± 1%  -47.44% (p=0.000 n=10)
HashPB/nesting=10-24    179.51µ ± 2%   93.98µ ± 0%  -47.65% (p=0.000 n=10)
HashPB/nesting=50-24     910.8µ ± 3%   475.7µ ± 2%  -47.77% (p=0.000 n=10)
HashPB/nesting=100-24   1843.4µ ± 2%   951.0µ ± 2%  -48.41% (p=0.000 n=10)
geomean                  216.3µ        113.9µ       -47.35%

                      │  before.txt  │              after.txt               │
                      │     B/s      │     B/s       vs base                │
HashPB/nesting=1-24     25.52Mi ± 1%   46.76Mi ± 2%  +83.26% (p=0.000 n=10)
HashPB/nesting=5-24     25.52Mi ± 3%   48.54Mi ± 1%  +90.24% (p=0.000 n=10)
HashPB/nesting=10-24    25.27Mi ± 2%   48.27Mi ± 0%  +91.00% (p=0.000 n=10)
HashPB/nesting=50-24    24.93Mi ± 3%   47.74Mi ± 2%  +91.47% (p=0.000 n=10)
HashPB/nesting=100-24   24.66Mi ± 2%   47.80Mi ± 2%  +93.85% (p=0.000 n=10)
geomean                 25.18Mi        47.82Mi       +89.93%

                      │  before.txt   │              after.txt               │
                      │     B/op      │     B/op      vs base                │
HashPB/nesting=1-24       1328.0 ± 0%     568.0 ± 0%  -57.23% (p=0.000 n=10)
HashPB/nesting=5-24      6.109Ki ± 0%   2.336Ki ± 0%  -61.76% (p=0.000 n=10)
HashPB/nesting=10-24    12.125Ki ± 0%   4.562Ki ± 0%  -62.37% (p=0.000 n=10)
HashPB/nesting=50-24     60.25Ki ± 0%   22.38Ki ± 0%  -62.86% (p=0.000 n=10)
HashPB/nesting=100-24   120.41Ki ± 0%   44.64Ki ± 0%  -62.93% (p=0.000 n=10)
geomean                  14.74Ki        5.679Ki       -61.49%

                      │  before.txt  │              after.txt              │
                      │  allocs/op   │  allocs/op   vs base                │
HashPB/nesting=1-24      120.00 ± 0%    24.00 ± 0%  -80.00% (p=0.000 n=10)
HashPB/nesting=5-24       592.0 ± 0%    108.0 ± 0%  -81.76% (p=0.000 n=10)
HashPB/nesting=10-24     1182.0 ± 0%    213.0 ± 0%  -81.98% (p=0.000 n=10)
HashPB/nesting=50-24     5.902k ± 0%   1.053k ± 0%  -82.16% (p=0.000 n=10)
HashPB/nesting=100-24   11.802k ± 0%   2.103k ± 0%  -82.18% (p=0.000 n=10)
geomean                  1.424k         261.5       -81.63%

```