### PR TITLE
Pooling buffers and map key slices

### DIFF
--- a/internal/pb/all_types_hashpb.pb.go
+++ b/internal/pb/all_types_hashpb.pb.go
@@ -12,8 +12,9 @@ import (
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		var b [10]byte
-		cerbos_hashpb_test_TestAllTypes_hashpb_sum(m, hasher, ignore, &b)
+		b := hashpb_bufPool.Get().(*[10]byte)
+		cerbos_hashpb_test_TestAllTypes_hashpb_sum(m, hasher, ignore, b)
+		hashpb_bufPool.Put(b)
 	}
 }
 
@@ -21,8 +22,9 @@ func (m *TestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypes_NestedMessage) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		var b [10]byte
-		cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m, hasher, ignore, &b)
+		b := hashpb_bufPool.Get().(*[10]byte)
+		cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m, hasher, ignore, b)
+		hashpb_bufPool.Put(b)
 	}
 }
 
@@ -30,8 +32,9 @@ func (m *TestAllTypes_NestedMessage) HashPB(hasher hash.Hash, ignore map[string]
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *NestedTestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		var b [10]byte
-		cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m, hasher, ignore, &b)
+		b := hashpb_bufPool.Get().(*[10]byte)
+		cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m, hasher, ignore, b)
+		hashpb_bufPool.Put(b)
 	}
 }
 
@@ -39,8 +42,9 @@ func (m *NestedTestAllTypes) HashPB(hasher hash.Hash, ignore map[string]struct{}
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypesOptional) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		var b [10]byte
-		cerbos_hashpb_test_TestAllTypesOptional_hashpb_sum(m, hasher, ignore, &b)
+		b := hashpb_bufPool.Get().(*[10]byte)
+		cerbos_hashpb_test_TestAllTypesOptional_hashpb_sum(m, hasher, ignore, b)
+		hashpb_bufPool.Put(b)
 	}
 }
 
@@ -48,7 +52,8 @@ func (m *TestAllTypesOptional) HashPB(hasher hash.Hash, ignore map[string]struct
 // The ignore set must contain fully-qualified field names (pkg.msg.field) that should be ignored from the hash
 func (m *TestAllTypesOptional_NestedMessage) HashPB(hasher hash.Hash, ignore map[string]struct{}) {
 	if m != nil {
-		var b [10]byte
-		cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m, hasher, ignore, &b)
+		b := hashpb_bufPool.Get().(*[10]byte)
+		cerbos_hashpb_test_TestAllTypesOptional_NestedMessage_hashpb_sum(m, hasher, ignore, b)
+		hashpb_bufPool.Put(b)
 	}
 }

--- a/internal/pb/hashpb_helpers.pb.go
+++ b/internal/pb/hashpb_helpers.pb.go
@@ -14,8 +14,33 @@ import (
 	maps "maps"
 	math "math"
 	slices "slices"
+	sync "sync"
 	unsafe "unsafe"
 )
+
+var hashpb_bufPool = sync.Pool{
+	New: func() any { return new([10]byte) },
+}
+
+var hashpb_stringKeyPool = sync.Pool{
+	New: func() any { return make([]string, 0, 32) },
+}
+
+var hashpb_int32KeyPool = sync.Pool{
+	New: func() any { return make([]int32, 0, 32) },
+}
+
+var hashpb_int64KeyPool = sync.Pool{
+	New: func() any { return make([]int64, 0, 32) },
+}
+
+var hashpb_uint32KeyPool = sync.Pool{
+	New: func() any { return make([]uint32, 0, 32) },
+}
+
+var hashpb_uint64KeyPool = sync.Pool{
+	New: func() any { return make([]uint64, 0, 32) },
+}
 
 func cerbos_hashpb_test_NestedTestAllTypes_hashpb_sum(m *NestedTestAllTypes, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["cerbos.hashpb.test.NestedTestAllTypes.child"]; !ok {
@@ -386,29 +411,72 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_string_string"]; !ok {
 		if len(m.MapStringString) > 0 {
-			for _, k := range slices.Sorted(maps.Keys(m.MapStringString)) {
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
-				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapStringString[k]))))
-				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapStringString[k]), len(m.MapStringString[k])))
+			if len(m.MapStringString) <= 32 {
+				keys := hashpb_stringKeyPool.Get().([]string)[:0]
+				for k := range m.MapStringString {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				for _, k := range keys {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapStringString[k]))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapStringString[k]), len(m.MapStringString[k])))
+				}
+				hashpb_stringKeyPool.Put(keys)
+			} else {
+				for _, k := range slices.Sorted(maps.Keys(m.MapStringString)) {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapStringString[k]))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapStringString[k]), len(m.MapStringString[k])))
+				}
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_uint64_string"]; !ok {
 		if len(m.MapUint64String) > 0 {
-			for _, k := range slices.Sorted(maps.Keys(m.MapUint64String)) {
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], k))
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapUint64String[k]))))
-				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapUint64String[k]), len(m.MapUint64String[k])))
+			if len(m.MapUint64String) <= 32 {
+				keys := hashpb_uint64KeyPool.Get().([]uint64)[:0]
+				for k := range m.MapUint64String {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				for _, k := range keys {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], k))
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapUint64String[k]))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapUint64String[k]), len(m.MapUint64String[k])))
+				}
+				hashpb_uint64KeyPool.Put(keys)
+			} else {
+				for _, k := range slices.Sorted(maps.Keys(m.MapUint64String)) {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], k))
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapUint64String[k]))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapUint64String[k]), len(m.MapUint64String[k])))
+				}
 			}
 		}
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_int32_string"]; !ok {
 		if len(m.MapInt32String) > 0 {
-			for _, k := range slices.Sorted(maps.Keys(m.MapInt32String)) {
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapInt32String[k]))))
-				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapInt32String[k]), len(m.MapInt32String[k])))
+			if len(m.MapInt32String) <= 32 {
+				keys := hashpb_int32KeyPool.Get().([]int32)[:0]
+				for k := range m.MapInt32String {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				for _, k := range keys {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapInt32String[k]))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapInt32String[k]), len(m.MapInt32String[k])))
+				}
+				hashpb_int32KeyPool.Put(keys)
+			} else {
+				for _, k := range slices.Sorted(maps.Keys(m.MapInt32String)) {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(m.MapInt32String[k]))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(m.MapInt32String[k]), len(m.MapInt32String[k])))
+				}
 			}
 		}
 	}
@@ -426,10 +494,25 @@ func cerbos_hashpb_test_TestAllTypes_hashpb_sum(m *TestAllTypes, hasher hash.Has
 	}
 	if _, ok := ignore["cerbos.hashpb.test.TestAllTypes.map_int64_nested_type"]; !ok {
 		if len(m.MapInt64NestedType) > 0 {
-			for _, k := range slices.Sorted(maps.Keys(m.MapInt64NestedType)) {
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
-				if m.MapInt64NestedType[k] != nil {
-					cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m.MapInt64NestedType[k], hasher, ignore, b)
+			if len(m.MapInt64NestedType) <= 32 {
+				keys := hashpb_int64KeyPool.Get().([]int64)[:0]
+				for k := range m.MapInt64NestedType {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				for _, k := range keys {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
+					if m.MapInt64NestedType[k] != nil {
+						cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m.MapInt64NestedType[k], hasher, ignore, b)
+					}
+				}
+				hashpb_int64KeyPool.Put(keys)
+			} else {
+				for _, k := range slices.Sorted(maps.Keys(m.MapInt64NestedType)) {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(k)))
+					if m.MapInt64NestedType[k] != nil {
+						cerbos_hashpb_test_TestAllTypes_NestedMessage_hashpb_sum(m.MapInt64NestedType[k], hasher, ignore, b)
+					}
 				}
 			}
 		}
@@ -585,11 +668,27 @@ func google_protobuf_StringValue_hashpb_sum(m *wrapperspb.StringValue, hasher ha
 func google_protobuf_Struct_hashpb_sum(m *structpb.Struct, hasher hash.Hash, ignore map[string]struct{}, b *[10]byte) {
 	if _, ok := ignore["google.protobuf.Struct.fields"]; !ok {
 		if len(m.Fields) > 0 {
-			for _, k := range slices.Sorted(maps.Keys(m.Fields)) {
-				_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
-				_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
-				if m.Fields[k] != nil {
-					google_protobuf_Value_hashpb_sum(m.Fields[k], hasher, ignore, b)
+			if len(m.Fields) <= 32 {
+				keys := hashpb_stringKeyPool.Get().([]string)[:0]
+				for k := range m.Fields {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				for _, k := range keys {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
+					if m.Fields[k] != nil {
+						google_protobuf_Value_hashpb_sum(m.Fields[k], hasher, ignore, b)
+					}
+				}
+				hashpb_stringKeyPool.Put(keys)
+			} else {
+				for _, k := range slices.Sorted(maps.Keys(m.Fields)) {
+					_, _ = hasher.Write(protowire.AppendVarint(b[:0], uint64(len(k))))
+					_, _ = hasher.Write(unsafe.Slice(unsafe.StringData(k), len(k)))
+					if m.Fields[k] != nil {
+						google_protobuf_Value_hashpb_sum(m.Fields[k], hasher, ignore, b)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
1. The buffers allocated for the AppendVarint escape to heap (https://github.com/cerbos/protoc-gen-go-hashpb/pull/49), thus we can/should pool them.
2. If a map's length doesn't exceed 32 items, get a pooled slice for sorting its keys, otherwise fallback to current behaviour.

Benchmark comparison with the latest (v0.4.2) release:
```txt
goos: linux
goarch: amd64
pkg: github.com/cerbos/protoc-gen-go-hashpb/internal/generator
cpu: AMD Ryzen AI 9 HX 370 w/ Radeon 890M           
                          │ benchmark-v0.4.2.txt │              final.txt              │
                          │        sec/op        │   sec/op     vs base                │
HashPB/nesting=1-24                 2.486µ ±  6%   1.018µ ± 2%  -59.08% (p=0.000 n=10)
HashPB/nesting=5-24                12.719µ ±  3%   4.940µ ± 2%  -61.16% (p=0.000 n=10)
HashPB/nesting=10-24                25.97µ ±  2%   10.00µ ± 2%  -61.48% (p=0.000 n=10)
HashPB/nesting=50-24               134.33µ ±  5%   50.24µ ± 2%  -62.60% (p=0.000 n=10)
HashPB/nesting=100-24               274.7µ ± 13%   101.7µ ± 6%  -62.99% (p=0.000 n=10)
HashPBBatch/nesting=1-24           1691.5µ ±  7%   554.4µ ± 9%  -67.22% (p=0.000 n=10)
HashPBBatch/nesting=5-24            8.467m ±  6%   2.748m ± 3%  -67.55% (p=0.000 n=10)
HashPBBatch/nesting=10-24          18.347m ±  3%   6.497m ± 5%  -64.59% (p=0.000 n=10)
geomean                             230.5µ         84.27µ       -63.44%

                          │ benchmark-v0.4.2.txt │               final.txt               │
                          │         B/s          │     B/s       vs base                 │
HashPB/nesting=1-24                181.6Mi ±  6%   443.4Mi ± 2%  +144.24% (p=0.000 n=10)
HashPB/nesting=5-24                178.2Mi ±  3%   458.9Mi ± 2%  +157.46% (p=0.000 n=10)
HashPB/nesting=10-24               174.7Mi ±  2%   453.5Mi ± 2%  +159.59% (p=0.000 n=10)
HashPB/nesting=50-24               169.0Mi ±  5%   452.0Mi ± 2%  +167.39% (p=0.000 n=10)
HashPB/nesting=100-24              165.4Mi ± 11%   447.0Mi ± 5%  +170.17% (p=0.000 n=10)
HashPBBatch/nesting=1-24           133.3Mi ±  6%   407.1Mi ± 8%  +205.33% (p=0.000 n=10)
HashPBBatch/nesting=5-24           133.9Mi ±  7%   412.5Mi ± 3%  +208.12% (p=0.000 n=10)
HashPBBatch/nesting=10-24          123.6Mi ±  3%   349.1Mi ± 5%  +182.41% (p=0.000 n=10)
geomean                            155.9Mi         426.4Mi       +173.52%

                          │ benchmark-v0.4.2.txt │              final.txt               │
                          │         B/op         │     B/op      vs base                │
HashPB/nesting=1-24                  1248.0 ± 0%     112.0 ± 0%  -91.03% (p=0.000 n=10)
HashPB/nesting=5-24                  6176.0 ± 0%     498.0 ± 0%  -91.94% (p=0.000 n=10)
HashPB/nesting=10-24                12336.0 ± 0%     981.0 ± 0%  -92.05% (p=0.000 n=10)
HashPB/nesting=50-24               60.172Ki ± 0%   4.731Ki ± 0%  -92.14% (p=0.000 n=10)
HashPB/nesting=100-24             120.329Ki ± 0%   9.456Ki ± 0%  -92.14% (p=0.000 n=10)
HashPBBatch/nesting=1-24           601.59Ki ± 0%   47.23Ki ± 0%  -92.15% (p=0.000 n=10)
HashPBBatch/nesting=5-24           3007.8Ki ± 0%   235.0Ki ± 0%  -92.19% (p=0.000 n=10)
HashPBBatch/nesting=10-24          6015.7Ki ± 0%   469.5Ki ± 0%  -92.20% (p=0.000 n=10)
geomean                             95.60Ki        7.662Ki       -91.99%

                          │ benchmark-v0.4.2.txt │              final.txt              │
                          │      allocs/op       │  allocs/op   vs base                │
HashPB/nesting=1-24                 119.000 ± 0%    5.000 ± 0%  -95.80% (p=0.000 n=10)
HashPB/nesting=5-24                  591.00 ± 0%    21.00 ± 0%  -96.45% (p=0.000 n=10)
HashPB/nesting=10-24                1181.00 ± 0%    41.00 ± 0%  -96.53% (p=0.000 n=10)
HashPB/nesting=50-24                 5901.0 ± 0%    201.0 ± 0%  -96.59% (p=0.000 n=10)
HashPB/nesting=100-24               11801.0 ± 0%    401.0 ± 0%  -96.60% (p=0.000 n=10)
HashPBBatch/nesting=1-24            59.001k ± 0%   2.001k ± 0%  -96.61% (p=0.000 n=10)
HashPBBatch/nesting=5-24            295.00k ± 0%   10.00k ± 0%  -96.61% (p=0.000 n=10)
HashPBBatch/nesting=10-24           590.00k ± 0%   20.00k ± 0%  -96.61% (p=0.000 n=10)
geomean                              9.370k         329.5       -96.48%
```